### PR TITLE
Fixed week of year bug

### DIFF
--- a/src/main/java/com/michaelbaranov/microba/calendar/ui/basic/CalendarNumberOfWeekPanel.java
+++ b/src/main/java/com/michaelbaranov/microba/calendar/ui/basic/CalendarNumberOfWeekPanel.java
@@ -89,8 +89,10 @@ public class CalendarNumberOfWeekPanel extends JPanel /*
 			labels[i].setForeground(isEnabled() ? UIManager
 					.getColor("controlText") : UIManager
 					.getColor("textInactiveText"));
+			
+			calendar.add(Calendar.WEEK_OF_YEAR, 1);
+			startWeek = calendar.get(Calendar.WEEK_OF_YEAR);
 
-			startWeek++;
 			numActiveWeeks--;
 		}
 


### PR DESCRIPTION
startWeek has to be retrieved by Calendar for each week otherwise there will be wrong number of weeks in january 2016. This only applies to european countries as far as I know.