### PR TITLE
Add support for LLLL format in newer Java versions

### DIFF
--- a/src/main/java/com/michaelbaranov/microba/calendar/ui/basic/ClassicCalendarPanel.java
+++ b/src/main/java/com/michaelbaranov/microba/calendar/ui/basic/ClassicCalendarPanel.java
@@ -56,6 +56,8 @@ class ClassicCalendarPanel extends JPanel implements
 
 	private JButton fastNextButton;
 
+	private static final int JAVA_MAJOR_VERSION = Integer.parseInt(System.getProperty("java.version").split("\\.|_|-b")[1]);
+
 	public ClassicCalendarPanel(Date aDate, Locale aLocale, TimeZone zone) {
 		this.locale = aLocale;
 		this.zone = zone;
@@ -159,7 +161,7 @@ class ClassicCalendarPanel extends JPanel implements
 		} else
 			calendar = Calendar.getInstance(zone, locale);
 
-		format = new SimpleDateFormat("MMMMM yyyy", locale);
+		format = new SimpleDateFormat(JAVA_MAJOR_VERSION >= 8 ? "LLLL yyyy" : "MMMMM yyyy", locale);
 		format.setTimeZone(zone);
 
 		setPreferredLabelSize();

--- a/src/main/java/com/michaelbaranov/microba/calendar/ui/basic/MonthComboBoxRenderer.java
+++ b/src/main/java/com/michaelbaranov/microba/calendar/ui/basic/MonthComboBoxRenderer.java
@@ -17,10 +17,12 @@ class MonthComboBoxRenderer extends DefaultListCellRenderer {
 
 	private SimpleDateFormat dateFormat;
 
+	private static final int JAVA_MAJOR_VERSION = Integer.parseInt(System.getProperty("java.version").split("\\.|_|-b")[1]);
+
 	public MonthComboBoxRenderer(Locale locale, TimeZone zone) {
 		// this.locale = locale;
 		this.zone = zone;
-		dateFormat = new SimpleDateFormat("MMMM", locale);
+		dateFormat = new SimpleDateFormat(JAVA_MAJOR_VERSION >= 8 ? "LLLL" : "MMMM", locale);
 		dateFormat.setTimeZone(zone);
 	}
 
@@ -37,7 +39,7 @@ class MonthComboBoxRenderer extends DefaultListCellRenderer {
 
 	public void setLocale(Locale locale) {
 		// this.locale = locale;
-		dateFormat = new SimpleDateFormat("MMMM", locale);
+		dateFormat = new SimpleDateFormat(JAVA_MAJOR_VERSION >= 8 ? "LLLL" : "MMMM", locale);
 		dateFormat.setTimeZone(zone);
 	}
 


### PR DESCRIPTION
According to https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
LLLL format is prefered for standalone month names
This feature is not documented in Java 7 and earlier. I can't test it in earlier versions so it is the  reason to use the Java version test
